### PR TITLE
Clarify question endpoints and document uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# chatbot-ia
+# Chatbot IA Backend
+
+This project exposes a simple API for uploading PDF documents and asking
+questions based on their content.
+
+## Endpoints
+
+- `POST /api/docs/upload` — Upload a PDF file. The text is split into chunks,
+  embedded and stored for later retrieval.
+- `POST /api/ask` — Ask a question using the information extracted from the
+  uploaded documents. Returns the answer and the source text snippets.
+- `POST /api/chat` — Free-form chat with the language model without using the
+  document context.
+- `GET /api/health` — Basic health check.
+
+## Development
+
+Install dependencies from `backend/requirements.txt` and run the FastAPI app:
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/backend/app/api/routers/ask.py
+++ b/backend/app/api/routers/ask.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, HTTPException
-from app.models.schemas import QueryRequest, QueryResponse, SourceChunk
+from app.models.schemas import AskRequest, AskResponse, SourceChunk
 from app.services.rag_pipeline import answer_with_context
 
 router = APIRouter()
 
-@router.post("/query", response_model=QueryResponse)
-def query(req: QueryRequest):
+@router.post("/ask", response_model=AskResponse)
+def ask(req: AskRequest):
     if not req.question or not req.question.strip():
         raise HTTPException(status_code=400, detail="Question is required")
 
@@ -27,6 +27,6 @@ def query(req: QueryRequest):
                 index=meta.get("index"),
                 distance=dist
             ))
-        return QueryResponse(reply=result["reply"], sources=sources)
+        return AskResponse(reply=result["reply"], sources=sources)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/routers/docs.py
+++ b/backend/app/api/routers/docs.py
@@ -5,7 +5,7 @@ from app.db.chroma_client import upsert_documents
 
 router = APIRouter()
 
-@router.post("/admin/upload")
+@router.post("/upload")
 async def upload_pdf(file: UploadFile = File(...)):
     if not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Only PDF files are accepted")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api.routers import health, chat, admin
-from app.api.routers import query as query_router
+from app.api.routers import health, chat, docs
+from app.api.routers import ask as ask_router
 
 app = FastAPI(title="Chatbot Backend", version="0.2.0")
 
@@ -15,8 +15,8 @@ app.add_middleware(
 
 app.include_router(health.router, prefix="/api", tags=["health"])
 app.include_router(chat.router,   prefix="/api", tags=["chat"])
-app.include_router(admin.router,  prefix="/api", tags=["admin"])
-app.include_router(query_router.router, prefix="/api", tags=["query"])
+app.include_router(docs.router,   prefix="/api/docs", tags=["docs"])
+app.include_router(ask_router.router, prefix="/api", tags=["ask"])
 
 @app.get("/")
 def root():

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,19 +1,20 @@
 from typing import List, Optional
 from pydantic import BaseModel
 
+
 class ChatRequest(BaseModel):
     message: str
+
 
 class ChatResponse(BaseModel):
     reply: str
 
-from typing import List, Optional
-from pydantic import BaseModel
 
-class QueryRequest(BaseModel):
+class AskRequest(BaseModel):
     question: str
     top_k: int = 4
-    score_threshold: Optional[float] = None  # ej: 0.2 (opcional)
+    score_threshold: Optional[float] = None
+
 
 class SourceChunk(BaseModel):
     text: str
@@ -21,6 +22,7 @@ class SourceChunk(BaseModel):
     index: Optional[int] = None
     distance: Optional[float] = None
 
-class QueryResponse(BaseModel):
+
+class AskResponse(BaseModel):
     reply: str
     sources: List[SourceChunk] = []


### PR DESCRIPTION
## Summary
- Rename query router to ask for context-based QA and adjust models
- Move PDF upload under docs router with simpler `/api/docs/upload` path
- Document new endpoints in README

## Testing
- `python -m py_compile backend/app/api/routers/ask.py backend/app/api/routers/docs.py backend/app/main.py backend/app/models/schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa6dd9d4832c88d065076d2e731d