### PR TITLE
feat: add pdf indexing backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Node
+frontend/node_modules
+
+# Python
+backend/__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Chatbot IA
+
+Este proyecto proporciona un frontend de administración para conversar con un modelo de lenguaje y la posibilidad de subir documentos PDF que se indexan para brindar respuestas basadas en su contenido.
+
+## Backend
+
+Un backend sencillo en **FastAPI** expone los siguientes endpoints:
+
+- `GET /models/`: lista de modelos disponibles.
+- `POST /upload/`: recibe un PDF y lo indexa en memoria.
+- `POST /chat/`: dada una pregunta y un `doc_id` opcional, devuelve el fragmento más relevante del PDF.
+
+Para ejecutar el backend:
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Frontend
+
+El panel de administración hecho con React permite seleccionar un modelo, subir un documento y chatear utilizando ese contexto.
+
+Para ejecutarlo en modo desarrollo:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Por defecto el frontend se comunica con el backend en `http://localhost:8000`. Puedes cambiarlo definiendo la variable de entorno `VITE_API_URL`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,77 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from uuid import uuid4
+import io
+from pypdf import PdfReader
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# In-memory store for indexed documents
+# doc_id -> {"chunks": [str], "vectorizer": TfidfVectorizer, "matrix": csr_matrix, "filename": str}
+DOCS = {}
+
+
+@app.get("/models/")
+async def list_models():
+    """Return available model names for the frontend selector."""
+    return {"models": [{"name": "dummy"}]}
+
+
+@app.post("/upload/")
+async def upload_pdf(file: UploadFile = File(...)):
+    """Receive a PDF, split it into chunks and index via TF-IDF."""
+    if file.content_type != "application/pdf":
+        raise HTTPException(status_code=400, detail="Solo se aceptan archivos PDF")
+
+    pdf_bytes = await file.read()
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    if not text.strip():
+        raise HTTPException(status_code=400, detail="No se pudo extraer texto del PDF")
+
+    chunk_size = 500
+    chunks = [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+    vectorizer = TfidfVectorizer().fit(chunks)
+    matrix = vectorizer.transform(chunks)
+
+    doc_id = str(uuid4())
+    DOCS[doc_id] = {
+        "chunks": chunks,
+        "vectorizer": vectorizer,
+        "matrix": matrix,
+        "filename": file.filename,
+    }
+
+    return {"doc_id": doc_id, "filename": file.filename, "upserted": len(chunks)}
+
+
+class ChatRequest(BaseModel):
+    model: str
+    prompt: str
+    doc_id: str | None = None
+
+
+@app.post("/chat/")
+async def chat(req: ChatRequest):
+    """Simple retrieval: return the most relevant chunk for the prompt."""
+    if req.doc_id and req.doc_id in DOCS:
+        data = DOCS[req.doc_id]
+        vec = data["vectorizer"].transform([req.prompt])
+        sims = cosine_similarity(vec, data["matrix"])[0]
+        idx = sims.argmax()
+        context = data["chunks"][idx]
+        reply = f"Fragmento relevante del documento: {context}"
+    else:
+        reply = "No hay documento indexado."
+
+    return {"message": {"role": "ai", "content": reply}}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pypdf
+scikit-learn

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,7 +28,8 @@ export default function App() {
     try {
       const form = new FormData();
       form.append("file", file);
-      const res = await fetch(`${import.meta.env.VITE_API_URL || "/api"}/upload/`, {
+      const base = import.meta.env.VITE_API_URL || "http://localhost:8000";
+      const res = await fetch(`${base}/upload/`, {
         method: "POST",
         body: form,
       });


### PR DESCRIPTION
## Summary
- add FastAPI backend to upload and query indexed PDFs
- allow frontend uploads to target backend
- document how to run backend and frontend

## Testing
- `python -m py_compile backend/main.py`
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b9c9d7ea38832ca032d3b2b4744f4c