### PR TITLE
feat: add pdf indexing backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Node
+frontend/node_modules
+
+# Python
+backend/__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Chatbot IA
+
+Este proyecto proporciona un frontend de administración para conversar con un modelo de lenguaje y la posibilidad de subir documentos PDF que se indexan para brindar respuestas basadas en su contenido.
+
+## Backend
+
+Un backend sencillo en **FastAPI** expone los siguientes endpoints:
+
+- `GET /models/`: lista de modelos disponibles.
+- `POST /upload/`: recibe un PDF y lo indexa en memoria.
+- `POST /chat/`: dada una pregunta y un `doc_id` opcional, devuelve el fragmento más relevante del PDF.
+
+Para ejecutar el backend:
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Frontend
+
+El panel de administración hecho con React permite seleccionar un modelo, subir un documento y chatear utilizando ese contexto.
+
+Para ejecutarlo en modo desarrollo:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Por defecto el frontend se comunica con el backend en `http://localhost:8000`. Puedes cambiarlo definiendo la variable de entorno `VITE_API_URL`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .routers.upload import router as upload_router
+from .routers.chat import router as chat_router
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/models/")
+async def list_models():
+    return {"models": [{"name": "dummy"}]}
+
+app.include_router(upload_router)
+app.include_router(chat_router)

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from ..services.rag_store import query_document
+
+router = APIRouter()
+
+
+class ChatRequest(BaseModel):
+    model: str
+    prompt: str
+    doc_id: str | None = None
+
+
+@router.post("/chat/")
+async def chat(req: ChatRequest):
+    if req.doc_id:
+        context = query_document(req.doc_id, req.prompt)
+        reply = f"Fragmento relevante del documento: {context}"
+    else:
+        reply = "No hay documento indexado."
+    return {"message": {"role": "ai", "content": reply}}

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -1,0 +1,23 @@
+import io
+from fastapi import APIRouter, UploadFile, File, HTTPException
+from pypdf import PdfReader
+from ..services.rag_store import upsert_document
+
+router = APIRouter()
+
+
+@router.post("/upload/")
+async def upload_pdf(file: UploadFile = File(...)):
+    if file.content_type != "application/pdf":
+        raise HTTPException(status_code=400, detail="Solo se aceptan archivos PDF")
+    pdf_bytes = await file.read()
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    if not text.strip():
+        raise HTTPException(status_code=400, detail="No se pudo extraer texto del PDF")
+    try:
+        result = upsert_document(text)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    result["filename"] = file.filename
+    return result

--- a/backend/app/services/rag_store.py
+++ b/backend/app/services/rag_store.py
@@ -1,0 +1,36 @@
+import uuid
+from typing import Dict
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+# doc_id -> {"chunks": list[str], "vectorizer": TfidfVectorizer, "matrix": csr_matrix}
+DOCUMENTS: Dict[str, Dict] = {}
+
+
+def split_text(text: str, chunk_size: int = 500) -> list[str]:
+    return [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+
+def upsert_document(text: str) -> dict:
+    chunks = [c.strip() for c in split_text(text) if c and c.strip()]
+    if not chunks:
+        raise ValueError("No se encontró texto válido en el documento")
+    vectorizer = TfidfVectorizer().fit(chunks)
+    matrix = vectorizer.transform(chunks)
+    doc_id = str(uuid.uuid4())
+    DOCUMENTS[doc_id] = {
+        "chunks": chunks,
+        "vectorizer": vectorizer,
+        "matrix": matrix,
+    }
+    return {"doc_id": doc_id, "upserted": len(chunks)}
+
+
+def query_document(doc_id: str, prompt: str) -> str:
+    data = DOCUMENTS.get(doc_id)
+    if not data:
+        return "No hay documento indexado."
+    vec = data["vectorizer"].transform([prompt])
+    sims = cosine_similarity(vec, data["matrix"])[0]
+    idx = sims.argmax()
+    return data["chunks"][idx]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,1 @@
+from app.main import app

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pypdf
+scikit-learn

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,7 +28,8 @@ export default function App() {
     try {
       const form = new FormData();
       form.append("file", file);
-      const res = await fetch(`${import.meta.env.VITE_API_URL || "/api"}/upload/`, {
+      const base = import.meta.env.VITE_API_URL || "http://localhost:8000";
+      const res = await fetch(`${base}/upload/`, {
         method: "POST",
         body: form,
       });


### PR DESCRIPTION
## Summary
- restructure backend into app package with upload and chat routers
- store PDF chunks via in-memory TF-IDF index and expose query utilities
- document running backend with `uvicorn app.main:app --reload`

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile backend/app/main.py backend/app/routers/upload.py backend/app/routers/chat.py backend/app/services/rag_store.py`
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b9c9d7ea38832ca032d3b2b4744f4c